### PR TITLE
fix(api): migrate dead post endpoint to PolarisPostRootQuery, add stories user-id fallback

### DIFF
--- a/src/js/post.js
+++ b/src/js/post.js
@@ -19,6 +19,27 @@ function convertToShortcode(postId) {
     return shortcode;
 }
 
+const IG_POST_ROOT_QUERY_DOC_ID = '27852811784380813';
+
+/**
+ * Instagram embeds the LSD and DTSG tokens in inline scripts of the
+ * server-rendered HTML. GraphQL POSTs without them get an HTML page back.
+ */
+function getWebSessionTokens() {
+    const tokens = { lsd: null, dtsg: null };
+    for (const script of document.querySelectorAll('script')) {
+        const text = script.textContent;
+        if (!tokens.lsd) tokens.lsd = text.match(/\["LSD",\[\],\{"token":"([^"]+)"\}/)?.[1] ?? null;
+        if (!tokens.dtsg)
+            tokens.dtsg =
+                text.match(/\["DTSGInitData",\[\],\{"token":"([^"]+)"/)?.[1] ??
+                text.match(/\["DTSGInitialData",\[\],\{"token":"([^"]+)"/)?.[1] ??
+                null;
+        if (tokens.lsd && tokens.dtsg) break;
+    }
+    return tokens;
+}
+
 async function getPostIdFromApi() {
     const cachedPostId = appCache.postIdInfoCache.get(appState.current.shortcode);
     if (cachedPostId) return cachedPostId;
@@ -46,19 +67,37 @@ async function getPostIdFromApi() {
 }
 
 async function getPostPhotos(shortcode) {
-    const postId = convertToPostId(shortcode);
-    const apiURL = new URL(`/api/v1/media/${postId}/info/`, IG_BASE_URL);
+    const apiURL = new URL('/graphql/query', IG_BASE_URL);
+    const { lsd, dtsg } = getWebSessionTokens();
+    const fetchOptions = getFetchOptions();
+    fetchOptions['method'] = 'POST';
+    fetchOptions.headers['content-type'] = 'application/x-www-form-urlencoded';
+    fetchOptions.headers['x-fb-friendly-name'] = 'PolarisPostRootQuery';
+    fetchOptions.headers['x-asbd-id'] = '129477';
+    if (lsd) fetchOptions.headers['x-fb-lsd'] = lsd;
+    fetchOptions.body = new URLSearchParams({
+        __d: 'www',
+        __user: '0',
+        __a: '1',
+        __req: '1',
+        __comet_req: '7',
+        fb_dtsg: dtsg ?? '',
+        lsd: lsd ?? '',
+        fb_api_caller_class: 'RelayModern',
+        fb_api_req_friendly_name: 'PolarisPostRootQuery',
+        server_timestamps: 'true',
+        doc_id: IG_POST_ROOT_QUERY_DOC_ID,
+        variables: JSON.stringify({
+            shortcode,
+            __relay_internal__pv__PolarisShortDramaEnabledrelayprovider: false,
+            __relay_internal__pv__PolarisMultiCaptionCarouselEnabledrelayprovider: false,
+        }),
+    }).toString();
     try {
         setPreferredMediaResolutionCookies();
-        let respone = await fetch(apiURL.href, getFetchOptions());
-        if (respone.status === 400) {
-            const postId = await getPostIdFromApi();
-            if (!postId) throw new Error('Network bug');
-            const apiURL = new URL(`/api/v1/media/${postId}/info/`, IG_BASE_URL);
-            respone = await fetch(apiURL.href, getFetchOptions());
-        }
+        const respone = await fetch(apiURL.href, fetchOptions);
         const json = await respone.json();
-        return json.items[0];
+        return json.data['xdt_api__v1__media__shortcode__web_info'].items[0];
     } catch (error) {
         console.log(error);
         return null;

--- a/src/js/story.js
+++ b/src/js/story.js
@@ -1,12 +1,13 @@
 async function getUserIdFromSearch(username) {
     if (appCache.userIdsCache.has(username)) return appCache.userIdsCache.get(username);
+    const query = username || appState.current.username;
     const apiURL = new URL('/web/search/topsearch/', IG_BASE_URL);
-    if (username) apiURL.searchParams.set('query', username);
-    else apiURL.searchParams.set('query', appState.current.username);
+    apiURL.searchParams.set('query', query);
     try {
         const respone = await fetch(apiURL.href);
         const json = await respone.json();
-        return json.users[0].user['pk_id'];
+        const exactMatch = json.users.find((item) => item.user['username'] === query);
+        return (exactMatch ?? json.users[0]).user['pk_id'];
     } catch (error) {
         console.log(error);
         return '';
@@ -62,7 +63,8 @@ async function downloadStoryPhotos(type = 'stories') {
         if (!appState.current.highlights) return null;
         json = await getHighlightStory(appState.current.highlights);
     } else {
-        const userId = await getUserId(appState.current.username);
+        const userId =
+            (await getUserId(appState.current.username)) || (await getUserIdFromSearch(appState.current.username));
         if (!userId) return null;
         json = await getStoryPhotos(userId);
     }


### PR DESCRIPTION
# Objective

Fixes #38.

Instagram is retiring the web endpoints this extension depends on, and the rollout looks gradual, per account or region. On my session posts, reels and business-account stories are all dead; on yours everything may still work, which is the annoying part of reviewing this.

What I found (full details in the issue):

- `/api/v1/media/<id>/info/` redirects to the homepage, so `getPostPhotos` chokes on HTML. The old GraphQL fallback (doc_id `8845758582119845`) is disabled server side, and since the redirect lands as a 200, the `status === 400` check never fires anyway.
- `/api/v1/users/web_profile_info/` returns 400 for business and creator accounts. Personal ones still work.

What this PR changes:

Posts and reels now go through `PolarisPostRootQuery`, the query instagram.com itself runs when you open a post today. It needs the LSD and DTSG tokens Instagram embeds in inline scripts of the server-rendered page, plus two relay provider variables. The good news: the payload (`data.xdt_api__v1__media__shortcode__web_info.items[0]`) has the same shape as the old REST `items[0]`, so `downloadPostPhotos` didn't have to change.

For stories, `downloadStoryPhotos` now falls back to the existing `getUserIdFromSearch` when `web_profile_info` fails. I also made it pick the exact username match from the search results instead of the first row, since the first result isn't always the profile you asked for.

A few notes for review:

- I left `getPostIdFromApi` and `convertToPostId` in place even though `getPostPhotos` no longer calls them, following the "avoid unnecessary refactoring" guideline. The new query takes the shortcode straight from the URL, the same way instagram.com does, which also covers the suffixed shortcodes of private profiles.
- The new doc_id is hardcoded like the previous one, so it will rot the same way when Instagram rotates it.
- `make format` passes with no changes.

Tested on: a single-image post, a 7-item carousel, a reel, stories from a personal account, stories from a business account (this exercises the fallback), and a 72-item highlight.

Release Notes:

- Fixed posts/reels downloads failing with an endless "Loading..." after Instagram retired the web media info endpoint.
- Fixed stories downloads for business/creator accounts.
