### PR TITLE
fix(download-media): disable Chrome native download button on preview videos

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -278,6 +278,9 @@ function renderMedia(data) {
             src: item.url,
             title: `${data.user.username} | ${item.id} | ${date}`,
             controls: '',
+            // Chrome's native download button bypasses saveMedia and fetches the
+            // signed CDN url directly, which the CDN rejects.
+            controlslist: 'nodownload',
             'data-format': item.format,
         };
         const ITEM_TEMPLATE = `<div>
@@ -288,7 +291,7 @@ function renderMedia(data) {
         const media = itemDOM.querySelector('img, video');
         Object.keys(attributes).forEach((key) => {
             if (item.isVideo) media.setAttribute(key, attributes[key]);
-            else if (key !== 'controls') media.setAttribute(key, attributes[key]);
+            else if (key !== 'controls' && key !== 'controlslist') media.setAttribute(key, attributes[key]);
         });
         media.addEventListener('click', (e) => {
             e.preventDefault();


### PR DESCRIPTION
# Objective

- `renderMedia` sets `controls` on preview videos, so Chrome draws its own player bar.
  The overflow menu in that bar has a Download item, and it never reaches `saveMedia`.
  Chrome fetches `video.src` itself, which is the signed CDN url, and the CDN refuses
  it. The download dies with `NETWORK_INVALID_REQUEST`, which the user sees as
  "Failed - Network error".
- Clicking the media has always worked. What bothers me is that the panel offers two
  ways to download and the one people can actually see is the broken one.
- I checked this against Chrome's own download history on an unmodified v5.1.19, one
  session. Five attempts from the player menu: all 0 bytes, all with the CDN url in the
  chain. Six clicks on the media: six complete files, every one with a `blob:` url.
  Nothing crossed over, and posts and stories behaved the same.
- `renderMedia` on `main` still sets `controls` and never sets `controlsList`, so this
  is live there too.
- To reproduce: open a post or story with a video, hit Download, then use the ⋮ menu in
  the player and pick Download. It fails. Click the video instead and you get the file.
- The fix is `controlsList="nodownload"` on preview videos. It drops the one control
  that cannot work. Playback is untouched and `saveMedia` stays the only path to a
  file. It is a one line change.

Release Notes:

- Fixed: the video player's built-in Download button in the preview panel no longer
  fails with a network error.
